### PR TITLE
transmission: update to 4.0.4

### DIFF
--- a/abi_used_symbols
+++ b/abi_used_symbols
@@ -85,6 +85,7 @@ libc.so.6:connect
 libc.so.6:copy_file_range
 libc.so.6:daemon
 libc.so.6:difftime
+libc.so.6:div
 libc.so.6:endmntent
 libc.so.6:execvp
 libc.so.6:exit
@@ -134,7 +135,6 @@ libc.so.6:isupper
 libc.so.6:isxdigit
 libc.so.6:listen
 libc.so.6:lldiv
-libc.so.6:localeconv
 libc.so.6:localtime_r
 libc.so.6:lseek
 libc.so.6:lstat
@@ -184,7 +184,6 @@ libc.so.6:select
 libc.so.6:send
 libc.so.6:sendto
 libc.so.6:setenv
-libc.so.6:setlocale
 libc.so.6:setmntent
 libc.so.6:setsockopt
 libc.so.6:sigaddset
@@ -1310,7 +1309,9 @@ libstdc++.so.6:_ZNSt28__atomic_futex_unsigned_base26_M_futex_wait_until_steadyEP
 libstdc++.so.6:_ZNSt3_V216generic_categoryEv
 libstdc++.so.6:_ZNSt6chrono3_V212steady_clock3nowEv
 libstdc++.so.6:_ZNSt6chrono3_V212system_clock3nowEv
+libstdc++.so.6:_ZNSt6locale6globalERKS_
 libstdc++.so.6:_ZNSt6locale7classicEv
+libstdc++.so.6:_ZNSt6localeC1EPKc
 libstdc++.so.6:_ZNSt6localeC1ERKS_
 libstdc++.so.6:_ZNSt6localeC1Ev
 libstdc++.so.6:_ZNSt6localeD1Ev
@@ -1377,6 +1378,7 @@ libstdc++.so.6:_ZSt28_Rb_tree_rebalance_for_erasePSt18_Rb_tree_node_baseRS_
 libstdc++.so.6:_ZSt28__throw_bad_array_new_lengthv
 libstdc++.so.6:_ZSt29_Rb_tree_insert_and_rebalancebPSt18_Rb_tree_node_baseS0_RS_
 libstdc++.so.6:_ZSt4cerr
+libstdc++.so.6:_ZSt4cout
 libstdc++.so.6:_ZSt7getlineIcSt11char_traitsIcESaIcEERSt13basic_istreamIT_T0_ES7_RNSt7__cxx1112basic_stringIS4_S5_T1_EES4_
 libstdc++.so.6:_ZSt9terminatev
 libstdc++.so.6:_ZSt9use_facetINSt7__cxx118numpunctIcEEERKT_RKSt6locale

--- a/package.yml
+++ b/package.yml
@@ -1,8 +1,8 @@
 name       : transmission
-version    : 4.0.3
-release    : 23
+version    : 4.0.4
+release    : 24
 source     :
-    - https://github.com/transmission/transmission/releases/download/4.0.3/transmission-4.0.3.tar.xz : b6b01fd58e42bb14f7aba0253db932ced050fcd2bba5d9f8469d77ddd8ad545a
+    - https://github.com/transmission/transmission/releases/download/4.0.4/transmission-4.0.4.tar.xz : 15f7b4318fdfbffb19aa8d9a6b0fd89348e6ef1e86baa21a0806ffd1893bd5a6
 homepage   : https://transmissionbt.com/
 license    : GPL-2.0-or-later
 component  : network.download

--- a/pspec_x86_64.xml
+++ b/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>transmission</Name>
         <Homepage>https://transmissionbt.com/</Homepage>
         <Packager>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Packager>
         <License>GPL-2.0-or-later</License>
         <PartOf>network.download</PartOf>
@@ -138,12 +138,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="23">
-            <Date>2023-08-22</Date>
-            <Version>4.0.3</Version>
+        <Update release="24">
+            <Date>2023-09-17</Date>
+            <Version>4.0.4</Version>
             <Comment>Packaging update</Comment>
-            <Name>Reilly Brogan</Name>
-            <Email>solus@reillybrogan.com</Email>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
**Changes:**
- Fixed bug in sending torrent metadata to peer
- Avoid unnecessary heap memory allocations
- Fixed filename collision edge case when renaming files
- Fixed locale errors that broke number rounding when displaying statistics, e.g. upload / download ratio
- Always use a fixed-length key query in tracker announces
- Fixed 4.0.0 bug where the port numbers in LDP announces are sometimes malformed
- Fixed a bug that prevented editing the query part of a tracker URL
- Fixed a bug where Transmission may not announce LPD on its listening interface
- Made small performance improvements in libtransmissio
- GTK: Fixed missing 'Remove torrent' tooltip
- transmission-remote: Fixed display bug that failed to show some torrent labels
- Ran all PNG files through lossless compressors to make them smaller

**Test Plan:**
- Managed my torrents

### Checklist

- [x] Package was built and tested against unstable
